### PR TITLE
Add read-only flow renderer component

### DIFF
--- a/packages/ui/src/components/FlowRenderer/CanvasHeaderWithToggle.jsx
+++ b/packages/ui/src/components/FlowRenderer/CanvasHeaderWithToggle.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+// material-ui
+import { Stack, Box } from '@mui/material'
+
+// project imports
+import CanvasHeader from '@/views/canvas/CanvasHeader'
+import FlowRendererToggle from './FlowRendererToggle'
+
+/**
+ * CanvasHeaderWithToggle - Enhanced Canvas Header with Editor/Renderer toggle
+ */
+const CanvasHeaderWithToggle = ({ 
+    chatflow, 
+    isAgentCanvas, 
+    isAgentflowV2, 
+    handleSaveFlow, 
+    handleDeleteFlow, 
+    handleLoadFlow,
+    viewMode,
+    onViewModeChange,
+    showToggle = true
+}) => {
+    return (
+        <Stack flexDirection='row' justifyContent='space-between' sx={{ width: '100%' }}>
+            {/* Original Canvas Header */}
+            <Box sx={{ flexGrow: 1 }}>
+                <CanvasHeader
+                    chatflow={chatflow}
+                    isAgentCanvas={isAgentCanvas}
+                    isAgentflowV2={isAgentflowV2}
+                    handleSaveFlow={handleSaveFlow}
+                    handleDeleteFlow={handleDeleteFlow}
+                    handleLoadFlow={handleLoadFlow}
+                />
+            </Box>
+            
+            {/* View Mode Toggle */}
+            {showToggle && (
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <FlowRendererToggle
+                        mode={viewMode}
+                        onModeChange={onViewModeChange}
+                        disabled={!chatflow?.flowData}
+                    />
+                </Box>
+            )}
+        </Stack>
+    )
+}
+
+CanvasHeaderWithToggle.propTypes = {
+    chatflow: PropTypes.object,
+    isAgentCanvas: PropTypes.bool,
+    isAgentflowV2: PropTypes.bool,
+    handleSaveFlow: PropTypes.func,
+    handleDeleteFlow: PropTypes.func,
+    handleLoadFlow: PropTypes.func,
+    viewMode: PropTypes.oneOf(['editor', 'renderer']),
+    onViewModeChange: PropTypes.func,
+    showToggle: PropTypes.bool
+}
+
+export default CanvasHeaderWithToggle

--- a/packages/ui/src/components/FlowRenderer/EnhancedCanvas.jsx
+++ b/packages/ui/src/components/FlowRenderer/EnhancedCanvas.jsx
@@ -1,0 +1,88 @@
+import React, { useState, useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+// material-ui
+import { Toolbar, Box, AppBar } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+// project imports
+import Canvas from '@/views/canvas'
+import FlowRenderer from './FlowRenderer'
+import CanvasHeaderWithToggle from './CanvasHeaderWithToggle'
+
+/**
+ * EnhancedCanvas - Canvas component with Editor/Renderer toggle functionality
+ * This component wraps the existing Canvas and adds FlowRenderer capability
+ */
+const EnhancedCanvas = () => {
+    const theme = useTheme()
+    const { state } = useLocation()
+    const [viewMode, setViewMode] = useState('editor')
+    const [flowData, setFlowData] = useState(null)
+    const [chatflow, setChatflow] = useState(null)
+    
+    // Extract flow data from Canvas component when it changes
+    useEffect(() => {
+        // Listen for flow data changes from the Canvas component
+        // This is a simplified approach - in a real implementation, 
+        // you might want to use a shared state management solution
+        const handleFlowDataChange = (event) => {
+            if (event.detail?.flowData) {
+                setFlowData(event.detail.flowData)
+            }
+            if (event.detail?.chatflow) {
+                setChatflow(event.detail.chatflow)
+            }
+        }
+
+        window.addEventListener('flowDataChanged', handleFlowDataChange)
+        return () => {
+            window.removeEventListener('flowDataChanged', handleFlowDataChange)
+        }
+    }, [])
+
+    const handleViewModeChange = (newMode) => {
+        setViewMode(newMode)
+    }
+
+    // If in renderer mode and we have flow data, show the FlowRenderer
+    if (viewMode === 'renderer' && flowData) {
+        return (
+            <Box>
+                <AppBar
+                    enableColorOnDark
+                    position='fixed'
+                    color='inherit'
+                    elevation={1}
+                    sx={{
+                        bgcolor: theme.palette.background.default
+                    }}
+                >
+                    <Toolbar>
+                        <CanvasHeaderWithToggle
+                            chatflow={chatflow}
+                            viewMode={viewMode}
+                            onViewModeChange={handleViewModeChange}
+                            showToggle={true}
+                        />
+                    </Toolbar>
+                </AppBar>
+                <Box sx={{ pt: '70px', height: '100vh', width: '100%' }}>
+                    <FlowRenderer
+                        flowData={flowData}
+                        readOnly={true}
+                        showMiniMap={true}
+                        showControls={true}
+                        showBackground={true}
+                        style={{ height: '100%' }}
+                    />
+                </Box>
+            </Box>
+        )
+    }
+
+    // Otherwise, show the regular Canvas with the toggle
+    return <Canvas viewMode={viewMode} onViewModeChange={handleViewModeChange} />
+}
+
+export default EnhancedCanvas

--- a/packages/ui/src/components/FlowRenderer/FlowRenderer.jsx
+++ b/packages/ui/src/components/FlowRenderer/FlowRenderer.jsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useRef, useState, useMemo } from 'react'
+import PropTypes from 'prop-types'
+import ReactFlow, { Controls, Background, MiniMap, useNodesState, useEdgesState } from 'reactflow'
+import 'reactflow/dist/style.css'
+import '@/views/canvas/index.css'
+
+// material-ui
+import { Box, useTheme } from '@mui/material'
+
+// project imports
+import FlowRendererNode from './FlowRendererNode'
+import FlowRendererAgentNode from './FlowRendererAgentNode'
+import FlowRendererStickyNote from './FlowRendererStickyNote'
+import ButtonEdge from '@/views/canvas/ButtonEdge'
+import AgentFlowEdge from '@/views/agentflowsv2/AgentFlowEdge'
+
+// Default node types for different flow types
+const DEFAULT_NODE_TYPES = {
+    customNode: FlowRendererNode,
+    stickyNote: FlowRendererStickyNote,
+    agentFlow: FlowRendererAgentNode,
+    iteration: FlowRendererAgentNode
+}
+
+const DEFAULT_EDGE_TYPES = {
+    buttonedge: ButtonEdge,
+    agentFlow: AgentFlowEdge
+}
+
+/**
+ * FlowRenderer - A read-only component for rendering Flowise flows
+ * 
+ * @param {Object} props - Component props
+ * @param {Object} props.flowData - Flowise flow JSON with nodes and edges
+ * @param {boolean} [props.readOnly=true] - Whether the flow is read-only
+ * @param {boolean} [props.showMiniMap=false] - Whether to show the minimap
+ * @param {boolean} [props.showControls=true] - Whether to show flow controls
+ * @param {boolean} [props.showBackground=true] - Whether to show the background grid
+ * @param {Object} [props.nodeComponentMap={}] - Custom node component mappings
+ * @param {Function} [props.onNodeClick] - Callback for node click events
+ * @param {Function} [props.onNodeDoubleClick] - Callback for node double click events
+ * @param {Object} [props.style] - Custom styles for the container
+ * @param {string} [props.className] - Custom CSS class for the container
+ * @param {number} [props.minZoom=0.1] - Minimum zoom level
+ * @param {number} [props.maxZoom=2] - Maximum zoom level
+ * @param {boolean} [props.fitView=true] - Whether to fit the view on initial render
+ */
+const FlowRenderer = ({
+    flowData,
+    readOnly = true,
+    showMiniMap = false,
+    showControls = true,
+    showBackground = true,
+    nodeComponentMap = {},
+    onNodeClick,
+    onNodeDoubleClick,
+    style = {},
+    className = '',
+    minZoom = 0.1,
+    maxZoom = 2,
+    fitView = true,
+    ...otherProps
+}) => {
+    const theme = useTheme()
+    const reactFlowWrapper = useRef(null)
+    const [reactFlowInstance, setReactFlowInstance] = useState(null)
+    
+    // Merge custom node types with defaults
+    const nodeTypes = useMemo(() => ({
+        ...DEFAULT_NODE_TYPES,
+        ...nodeComponentMap
+    }), [nodeComponentMap])
+
+    // Determine edge types based on flow type
+    const edgeTypes = useMemo(() => {
+        if (!flowData?.edges?.length) return DEFAULT_EDGE_TYPES
+        
+        // Check if this is an agent flow
+        const hasAgentFlowEdges = flowData.edges.some(edge => edge.type === 'agentFlow')
+        const hasButtonEdges = flowData.edges.some(edge => edge.type === 'buttonedge')
+        
+        if (hasAgentFlowEdges) {
+            return { agentFlow: AgentFlowEdge }
+        } else if (hasButtonEdges) {
+            return { buttonedge: ButtonEdge }
+        }
+        
+        return DEFAULT_EDGE_TYPES
+    }, [flowData])
+
+    // Initialize nodes and edges from flow data
+    const [nodes, setNodes, onNodesChange] = useNodesState(flowData?.nodes || [])
+    const [edges, setEdges, onEdgesChange] = useEdgesState(flowData?.edges || [])
+
+    // Update nodes and edges when flowData changes
+    useEffect(() => {
+        if (flowData) {
+            setNodes(flowData.nodes || [])
+            setEdges(flowData.edges || [])
+        }
+    }, [flowData, setNodes, setEdges])
+
+    // Handle node interactions
+    const handleNodeClick = (event, node) => {
+        if (onNodeClick && !readOnly) {
+            onNodeClick(event, node)
+        }
+    }
+
+    const handleNodeDoubleClick = (event, node) => {
+        if (onNodeDoubleClick && !readOnly) {
+            onNodeDoubleClick(event, node)
+        }
+    }
+
+    // Disable interactions in read-only mode
+    const handleNodesChange = readOnly ? () => {} : onNodesChange
+    const handleEdgesChange = readOnly ? () => {} : onEdgesChange
+
+    return (
+        <Box 
+            sx={{ 
+                height: '100%', 
+                width: '100%',
+                ...style 
+            }}
+            className={`flow-renderer ${className}`}
+        >
+            <div className='reactflow-parent-wrapper' style={{ height: '100%' }}>
+                <div className='reactflow-wrapper' ref={reactFlowWrapper} style={{ height: '100%' }}>
+                    <ReactFlow
+                        nodes={nodes}
+                        edges={edges}
+                        onNodesChange={handleNodesChange}
+                        onEdgesChange={handleEdgesChange}
+                        onNodeClick={handleNodeClick}
+                        onNodeDoubleClick={handleNodeDoubleClick}
+                        onInit={setReactFlowInstance}
+                        nodeTypes={nodeTypes}
+                        edgeTypes={edgeTypes}
+                        nodesDraggable={!readOnly}
+                        nodesConnectable={!readOnly}
+                        elementsSelectable={!readOnly}
+                        fitView={fitView}
+                        minZoom={minZoom}
+                        maxZoom={maxZoom}
+                        {...otherProps}
+                    >
+                        {showControls && (
+                            <Controls
+                                showZoom={true}
+                                showFitView={true}
+                                showInteractive={!readOnly}
+                                className={theme.customization?.isDarkMode ? 'dark-mode-controls' : ''}
+                            />
+                        )}
+                        {showBackground && <Background color='#aaa' gap={16} />}
+                        {showMiniMap && (
+                            <MiniMap
+                                nodeStrokeColor={(n) => {
+                                    if (n.style?.background) return n.style.background
+                                    if (n.type === 'input') return '#0041d0'
+                                    if (n.type === 'output') return '#ff0072'
+                                    if (n.type === 'default') return '#1a192b'
+                                    return '#eee'
+                                }}
+                                nodeColor={(n) => {
+                                    if (n.style?.background) return n.style.background
+                                    return '#fff'
+                                }}
+                                nodeBorderRadius={2}
+                            />
+                        )}
+                    </ReactFlow>
+                </div>
+            </div>
+        </Box>
+    )
+}
+
+FlowRenderer.propTypes = {
+    flowData: PropTypes.shape({
+        nodes: PropTypes.array.isRequired,
+        edges: PropTypes.array.isRequired
+    }).isRequired,
+    readOnly: PropTypes.bool,
+    showMiniMap: PropTypes.bool,
+    showControls: PropTypes.bool,
+    showBackground: PropTypes.bool,
+    nodeComponentMap: PropTypes.object,
+    onNodeClick: PropTypes.func,
+    onNodeDoubleClick: PropTypes.func,
+    style: PropTypes.object,
+    className: PropTypes.string,
+    minZoom: PropTypes.number,
+    maxZoom: PropTypes.number,
+    fitView: PropTypes.bool
+}
+
+export default FlowRenderer

--- a/packages/ui/src/components/FlowRenderer/FlowRenderer.test.jsx
+++ b/packages/ui/src/components/FlowRenderer/FlowRenderer.test.jsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { Provider } from 'react-redux'
+import { ThemeProvider } from '@mui/material/styles'
+import { store } from '@/store'
+import themes from '@/themes'
+import FlowRenderer from './FlowRenderer'
+
+// Mock ReactFlow since it requires DOM setup
+jest.mock('reactflow', () => ({
+    ...jest.requireActual('reactflow'),
+    __esModule: true,
+    default: ({ children, ...props }) => <div data-testid="react-flow" {...props}>{children}</div>,
+    Controls: ({ children }) => <div data-testid="controls">{children}</div>,
+    Background: () => <div data-testid="background" />,
+    MiniMap: () => <div data-testid="minimap" />,
+    useNodesState: () => [[], jest.fn(), jest.fn()],
+    useEdgesState: () => [[], jest.fn(), jest.fn()]
+}))
+
+const mockFlowData = {
+    nodes: [
+        {
+            id: 'test-node-1',
+            type: 'customNode',
+            position: { x: 100, y: 100 },
+            data: {
+                id: 'test-node-1',
+                label: 'Test Node',
+                name: 'testNode',
+                inputAnchors: [],
+                inputParams: [],
+                outputAnchors: [],
+                inputs: {}
+            }
+        }
+    ],
+    edges: []
+}
+
+const renderWithProviders = (ui, options = {}) => {
+    const customization = { isDarkMode: false }
+    
+    return render(
+        <Provider store={store}>
+            <ThemeProvider theme={themes(customization)}>
+                {ui}
+            </ThemeProvider>
+        </Provider>,
+        options
+    )
+}
+
+describe('FlowRenderer', () => {
+    test('renders without crashing', () => {
+        renderWithProviders(<FlowRenderer flowData={mockFlowData} />)
+        expect(screen.getByTestId('react-flow')).toBeInTheDocument()
+    })
+
+    test('renders with controls by default', () => {
+        renderWithProviders(<FlowRenderer flowData={mockFlowData} />)
+        expect(screen.getByTestId('controls')).toBeInTheDocument()
+    })
+
+    test('renders with background by default', () => {
+        renderWithProviders(<FlowRenderer flowData={mockFlowData} />)
+        expect(screen.getByTestId('background')).toBeInTheDocument()
+    })
+
+    test('shows minimap when enabled', () => {
+        renderWithProviders(<FlowRenderer flowData={mockFlowData} showMiniMap={true} />)
+        expect(screen.getByTestId('minimap')).toBeInTheDocument()
+    })
+
+    test('hides minimap when disabled', () => {
+        renderWithProviders(<FlowRenderer flowData={mockFlowData} showMiniMap={false} />)
+        expect(screen.queryByTestId('minimap')).not.toBeInTheDocument()
+    })
+
+    test('hides controls when disabled', () => {
+        renderWithProviders(<FlowRenderer flowData={mockFlowData} showControls={false} />)
+        expect(screen.queryByTestId('controls')).not.toBeInTheDocument()
+    })
+
+    test('hides background when disabled', () => {
+        renderWithProviders(<FlowRenderer flowData={mockFlowData} showBackground={false} />)
+        expect(screen.queryByTestId('background')).not.toBeInTheDocument()
+    })
+
+    test('applies custom className', () => {
+        renderWithProviders(<FlowRenderer flowData={mockFlowData} className="custom-class" />)
+        expect(document.querySelector('.custom-class')).toBeInTheDocument()
+    })
+
+    test('handles empty flow data', () => {
+        const emptyFlowData = { nodes: [], edges: [] }
+        renderWithProviders(<FlowRenderer flowData={emptyFlowData} />)
+        expect(screen.getByTestId('react-flow')).toBeInTheDocument()
+    })
+})

--- a/packages/ui/src/components/FlowRenderer/FlowRendererAgentNode.jsx
+++ b/packages/ui/src/components/FlowRenderer/FlowRendererAgentNode.jsx
@@ -1,0 +1,461 @@
+import PropTypes from 'prop-types'
+import { memo, useRef, useState, useEffect } from 'react'
+import { Handle, Position, useUpdateNodeInternals } from 'reactflow'
+
+// material-ui
+import { styled, useTheme, alpha, darken, lighten } from '@mui/material/styles'
+import { Avatar, Box, Typography, Tooltip } from '@mui/material'
+
+// project imports
+import MainCard from '@/ui-component/cards/MainCard'
+
+// icons
+import {
+    IconCheck,
+    IconExclamationMark,
+    IconCircleChevronRightFilled,
+    IconLoader,
+    IconAlertCircleFilled,
+    IconCode,
+    IconWorldWww,
+    IconPhoto
+} from '@tabler/icons-react'
+import StopCircleIcon from '@mui/icons-material/StopCircle'
+import CancelIcon from '@mui/icons-material/Cancel'
+
+// const
+import { baseURL, AGENTFLOW_ICONS } from '@/store/constant'
+
+const CardWrapper = styled(MainCard)(({ theme }) => ({
+    background: theme.palette.card.main,
+    color: theme.darkTextPrimary,
+    border: 'solid 1px',
+    width: 'max-content',
+    height: 'auto',
+    padding: '10px',
+    boxShadow: 'none'
+}))
+
+// ===========================|| FLOW RENDERER AGENT NODE ||=========================== //
+
+/**
+ * FlowRendererAgentNode - Read-only version of AgentFlowNode for FlowRenderer
+ */
+const FlowRendererAgentNode = ({ data, readOnly = true }) => {
+    const theme = useTheme()
+    const ref = useRef(null)
+    const updateNodeInternals = useUpdateNodeInternals()
+    const [position, setPosition] = useState(0)
+    const [isHovered, setIsHovered] = useState(false)
+
+    const defaultColor = '#666666'
+    const nodeColor = data.color || defaultColor
+
+    // Get different shades of the color based on state
+    const getStateColor = () => {
+        if (data.selected) return nodeColor
+        if (isHovered && !readOnly) return alpha(nodeColor, 0.8)
+        return alpha(nodeColor, 0.5)
+    }
+
+    const getOutputAnchors = () => {
+        return data.outputAnchors ?? []
+    }
+
+    const getAnchorPosition = (index) => {
+        const currentHeight = ref.current?.clientHeight || 0
+        const spacing = currentHeight / (getOutputAnchors().length + 1)
+        const position = spacing * (index + 1)
+
+        if (position > 0) {
+            updateNodeInternals(data.id)
+        }
+
+        return position
+    }
+
+    const getMinimumHeight = () => {
+        const outputCount = getOutputAnchors().length
+        return Math.max(60, outputCount * 20 + 40)
+    }
+
+    const getBackgroundColor = () => {
+        if (theme.customization?.isDarkMode) {
+            return isHovered && !readOnly ? darken(nodeColor, 0.7) : darken(nodeColor, 0.8)
+        }
+        return isHovered && !readOnly ? lighten(nodeColor, 0.8) : lighten(nodeColor, 0.9)
+    }
+
+    const getStatusBackgroundColor = (status) => {
+        switch (status) {
+            case 'ERROR':
+                return theme.palette.error.dark
+            case 'INPROGRESS':
+                return theme.palette.warning.dark
+            case 'STOPPED':
+            case 'TERMINATED':
+                return theme.palette.error.main
+            case 'FINISHED':
+                return theme.palette.success.dark
+            default:
+                return theme.palette.primary.dark
+        }
+    }
+
+    const renderIcon = (node) => {
+        const foundIcon = AGENTFLOW_ICONS.find((icon) => icon.name === node.name)
+        if (!foundIcon) return null
+        return <foundIcon.icon size={24} color={'white'} />
+    }
+
+    const getBuiltInOpenAIToolIcon = (toolName) => {
+        switch (toolName) {
+            case 'web_search_preview':
+                return <IconWorldWww size={14} color={'white'} />
+            case 'code_interpreter':
+                return <IconCode size={14} color={'white'} />
+            case 'image_generation':
+                return <IconPhoto size={14} color={'white'} />
+            default:
+                return null
+        }
+    }
+
+    useEffect(() => {
+        if (ref.current) {
+            setTimeout(() => {
+                setPosition(ref.current?.offsetTop + ref.current?.clientHeight / 2)
+                updateNodeInternals(data.id)
+            }, 10)
+        }
+    }, [data, ref, updateNodeInternals])
+
+    return (
+        <div 
+            ref={ref} 
+            onMouseEnter={() => !readOnly && setIsHovered(true)} 
+            onMouseLeave={() => !readOnly && setIsHovered(false)}
+        >
+            <CardWrapper
+                content={false}
+                sx={{
+                    borderColor: getStateColor(),
+                    borderWidth: '1px',
+                    boxShadow: data.selected ? `0 0 0 1px ${getStateColor()} !important` : 'none',
+                    minHeight: getMinimumHeight(),
+                    height: 'auto',
+                    backgroundColor: getBackgroundColor(),
+                    display: 'flex',
+                    alignItems: 'center',
+                    '&:hover': {
+                        boxShadow: data.selected ? `0 0 0 1px ${getStateColor()} !important` : 'none'
+                    }
+                }}
+                border={false}
+            >
+                {data && data.status && (
+                    <Tooltip title={data.status === 'ERROR' ? data.error || 'Error' : ''}>
+                        <Avatar
+                            variant='rounded'
+                            sx={{
+                                ...theme.typography.smallAvatar,
+                                borderRadius: '50%',
+                                background:
+                                    data.status === 'STOPPED' || data.status === 'TERMINATED'
+                                        ? 'white'
+                                        : getStatusBackgroundColor(data.status),
+                                color: 'white',
+                                ml: 2,
+                                position: 'absolute',
+                                top: -10,
+                                right: -10
+                            }}
+                        >
+                            {data.status === 'INPROGRESS' ? (
+                                <IconLoader className='spin-animation' />
+                            ) : data.status === 'ERROR' ? (
+                                <IconExclamationMark />
+                            ) : data.status === 'TERMINATED' ? (
+                                <CancelIcon sx={{ color: getStatusBackgroundColor(data.status) }} />
+                            ) : data.status === 'STOPPED' ? (
+                                <StopCircleIcon sx={{ color: getStatusBackgroundColor(data.status) }} />
+                            ) : (
+                                <IconCheck />
+                            )}
+                        </Avatar>
+                    </Tooltip>
+                )}
+
+                <Box sx={{ width: '100%' }}>
+                    {!data.hideInput && (
+                        <Handle
+                            type='target'
+                            position={Position.Left}
+                            id={data.id}
+                            style={{
+                                width: 5,
+                                height: 20,
+                                backgroundColor: 'transparent',
+                                border: 'none',
+                                position: 'absolute',
+                                left: -2
+                            }}
+                        >
+                            <div
+                                style={{
+                                    width: 5,
+                                    height: 20,
+                                    backgroundColor: nodeColor,
+                                    position: 'absolute',
+                                    left: '50%',
+                                    top: '50%',
+                                    transform: 'translate(-50%, -50%)'
+                                }}
+                            />
+                        </Handle>
+                    )}
+
+                    <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+                        <Box item style={{ width: 50 }}>
+                            {data.color && !data.icon ? (
+                                <div
+                                    style={{
+                                        ...theme.typography.commonAvatar,
+                                        ...theme.typography.largeAvatar,
+                                        borderRadius: '15px',
+                                        backgroundColor: data.color,
+                                        cursor: readOnly ? 'default' : 'grab',
+                                        display: 'flex',
+                                        justifyContent: 'center',
+                                        alignItems: 'center',
+                                        background: data.color
+                                    }}
+                                >
+                                    {renderIcon(data)}
+                                </div>
+                            ) : (
+                                <div
+                                    style={{
+                                        ...theme.typography.commonAvatar,
+                                        ...theme.typography.largeAvatar,
+                                        borderRadius: '50%',
+                                        backgroundColor: 'white',
+                                        cursor: readOnly ? 'default' : 'grab'
+                                    }}
+                                >
+                                    <img
+                                        style={{ width: '100%', height: '100%', padding: 5, objectFit: 'contain' }}
+                                        src={`${baseURL}/api/v1/node-icon/${data.name}`}
+                                        alt={data.name}
+                                    />
+                                </div>
+                            )}
+                        </Box>
+                        <Box>
+                            <Typography
+                                sx={{
+                                    fontSize: '0.85rem',
+                                    fontWeight: 500
+                                }}
+                            >
+                                {data.label}
+                            </Typography>
+
+                            {(() => {
+                                // Array of model configs to check and render
+                                const modelConfigs = [
+                                    { model: data.inputs?.llmModel, config: data.inputs?.llmModelConfig },
+                                    { model: data.inputs?.agentModel, config: data.inputs?.agentModelConfig },
+                                    { model: data.inputs?.conditionAgentModel, config: data.inputs?.conditionAgentModelConfig }
+                                ]
+
+                                // Filter out undefined models and render each valid one
+                                return modelConfigs
+                                    .filter((item) => item.model && item.config)
+                                    .map((item, index) => (
+                                        <Box key={`model-${index}`} sx={{ display: 'flex', gap: 1, mt: 1 }}>
+                                            <Box
+                                                sx={{
+                                                    backgroundColor: theme.customization?.isDarkMode
+                                                        ? 'rgba(255, 255, 255, 0.2)'
+                                                        : 'rgba(255, 255, 255, 0.9)',
+                                                    borderRadius: '16px',
+                                                    width: 'max-content',
+                                                    height: 24,
+                                                    pl: 1,
+                                                    pr: 1,
+                                                    display: 'flex',
+                                                    justifyContent: 'center',
+                                                    alignItems: 'center'
+                                                }}
+                                            >
+                                                <img
+                                                    style={{ width: 20, height: 20, objectFit: 'contain' }}
+                                                    src={`${baseURL}/api/v1/node-icon/${item.model}`}
+                                                    alt={item.model}
+                                                />
+                                                <Typography sx={{ fontSize: '0.7rem', ml: 0.5 }}>
+                                                    {item.config.modelName || item.config.model}
+                                                </Typography>
+                                            </Box>
+                                        </Box>
+                                    ))
+                            })()}
+
+                            {(() => {
+                                // Array of tool configurations to check and render
+                                const toolConfigs = [
+                                    { tools: data.inputs?.llmTools, toolProperty: 'llmSelectedTool' },
+                                    { tools: data.inputs?.agentTools, toolProperty: 'agentSelectedTool' },
+                                    {
+                                        tools:
+                                            data.inputs?.selectedTool ?? data.inputs?.toolAgentflowSelectedTool
+                                                ? [{ selectedTool: data.inputs?.selectedTool ?? data.inputs?.toolAgentflowSelectedTool }]
+                                                : [],
+                                        toolProperty: ['selectedTool', 'toolAgentflowSelectedTool']
+                                    },
+                                    { tools: data.inputs?.agentKnowledgeVSEmbeddings, toolProperty: ['vectorStore', 'embeddingModel'] },
+                                    {
+                                        tools: data.inputs?.agentToolsBuiltInOpenAI
+                                            ? (typeof data.inputs.agentToolsBuiltInOpenAI === 'string'
+                                                  ? JSON.parse(data.inputs.agentToolsBuiltInOpenAI)
+                                                  : data.inputs.agentToolsBuiltInOpenAI
+                                              ).map((tool) => ({ builtInTool: tool }))
+                                            : [],
+                                        toolProperty: 'builtInTool',
+                                        isBuiltInOpenAI: true
+                                    }
+                                ]
+
+                                // Filter out undefined tools and render each valid collection
+                                return toolConfigs
+                                    .filter((config) => config.tools && config.tools.length > 0)
+                                    .map((config, configIndex) => (
+                                        <Box key={`tools-${configIndex}`} sx={{ display: 'flex', gap: 1, mt: 1 }}>
+                                            {config.tools.flatMap((tool, toolIndex) => {
+                                                if (Array.isArray(config.toolProperty)) {
+                                                    return config.toolProperty
+                                                        .filter((prop) => tool[prop])
+                                                        .map((prop, propIndex) => {
+                                                            const toolName = tool[prop]
+                                                            return (
+                                                                <Box
+                                                                    key={`tool-${configIndex}-${toolIndex}-${propIndex}`}
+                                                                    component='img'
+                                                                    src={`${baseURL}/api/v1/node-icon/${toolName}`}
+                                                                    alt={toolName}
+                                                                    sx={{
+                                                                        width: 20,
+                                                                        height: 20,
+                                                                        borderRadius: '50%',
+                                                                        backgroundColor: 'rgba(255, 255, 255, 0.2)',
+                                                                        padding: 0.3
+                                                                    }}
+                                                                />
+                                                            )
+                                                        })
+                                                } else {
+                                                    const toolName = tool[config.toolProperty]
+                                                    if (!toolName) return []
+
+                                                    // Handle built-in OpenAI tools with icons
+                                                    if (config.isBuiltInOpenAI) {
+                                                        const icon = getBuiltInOpenAIToolIcon(toolName)
+                                                        if (!icon) return []
+
+                                                        return [
+                                                            <Box
+                                                                key={`tool-${configIndex}-${toolIndex}`}
+                                                                sx={{
+                                                                    width: 20,
+                                                                    height: 20,
+                                                                    borderRadius: '50%',
+                                                                    backgroundColor: theme.customization?.isDarkMode
+                                                                        ? darken(data.color, 0.5)
+                                                                        : darken(data.color, 0.2),
+                                                                    display: 'flex',
+                                                                    justifyContent: 'center',
+                                                                    alignItems: 'center',
+                                                                    padding: 0.2
+                                                                }}
+                                                            >
+                                                                {icon}
+                                                            </Box>
+                                                        ]
+                                                    }
+
+                                                    return [
+                                                        <Box
+                                                            key={`tool-${configIndex}-${toolIndex}`}
+                                                            component='img'
+                                                            src={`${baseURL}/api/v1/node-icon/${toolName}`}
+                                                            alt={toolName}
+                                                            sx={{
+                                                                width: 20,
+                                                                height: 20,
+                                                                borderRadius: '50%',
+                                                                backgroundColor: 'rgba(255, 255, 255, 0.2)',
+                                                                padding: 0.3
+                                                            }}
+                                                        />
+                                                    ]
+                                                }
+                                            })}
+                                        </Box>
+                                    ))
+                            })()}
+                        </Box>
+                    </div>
+                    {getOutputAnchors().map((outputAnchor, index) => {
+                        return (
+                            <Handle
+                                type='source'
+                                position={Position.Right}
+                                key={outputAnchor.id}
+                                id={outputAnchor.id}
+                                style={{
+                                    height: 20,
+                                    width: 20,
+                                    top: getAnchorPosition(index),
+                                    backgroundColor: 'transparent',
+                                    border: 'none',
+                                    position: 'absolute',
+                                    right: -10,
+                                    opacity: readOnly ? 0.7 : (isHovered ? 1 : 0),
+                                    transition: 'opacity 0.2s'
+                                }}
+                            >
+                                <div
+                                    style={{
+                                        position: 'absolute',
+                                        width: 20,
+                                        height: 20,
+                                        borderRadius: '50%',
+                                        backgroundColor: theme.palette.background.paper,
+                                        pointerEvents: 'none'
+                                    }}
+                                />
+                                <IconCircleChevronRightFilled
+                                    size={20}
+                                    color={nodeColor}
+                                    style={{
+                                        pointerEvents: 'none',
+                                        position: 'relative',
+                                        zIndex: 1
+                                    }}
+                                />
+                            </Handle>
+                        )
+                    })}
+                </Box>
+            </CardWrapper>
+        </div>
+    )
+}
+
+FlowRendererAgentNode.propTypes = {
+    data: PropTypes.object.isRequired,
+    readOnly: PropTypes.bool
+}
+
+export default memo(FlowRendererAgentNode)

--- a/packages/ui/src/components/FlowRenderer/FlowRendererNode.jsx
+++ b/packages/ui/src/components/FlowRenderer/FlowRendererNode.jsx
@@ -1,0 +1,188 @@
+import PropTypes from 'prop-types'
+import { useState, memo } from 'react'
+
+// material-ui
+import { useTheme } from '@mui/material/styles'
+import { Box, Typography, Divider, Button } from '@mui/material'
+
+// project imports
+import NodeCardWrapper from '@/ui-component/cards/NodeCardWrapper'
+import NodeInputHandler from '@/views/canvas/NodeInputHandler'
+import NodeOutputHandler from '@/views/canvas/NodeOutputHandler'
+import AdditionalParamsDialog from '@/ui-component/dialog/AdditionalParamsDialog'
+
+// const
+import { baseURL } from '@/store/constant'
+import LlamaindexPNG from '@/assets/images/llamaindex.png'
+
+// ===========================|| FLOW RENDERER NODE ||=========================== //
+
+/**
+ * FlowRendererNode - Read-only version of CanvasNode for FlowRenderer
+ * Based on MarketplaceCanvasNode but with additional customization options
+ */
+const FlowRendererNode = ({ data, readOnly = true, showAdditionalParams = false }) => {
+    const theme = useTheme()
+    
+    const [showDialog, setShowDialog] = useState(false)
+    const [dialogProps, setDialogProps] = useState({})
+
+    const onDialogClicked = () => {
+        if (!readOnly && showAdditionalParams) {
+            const dialogProps = {
+                data,
+                inputParams: data.inputParams.filter((param) => param.additionalParams),
+                disabled: readOnly,
+                confirmButtonName: 'Save',
+                cancelButtonName: 'Cancel'
+            }
+            setDialogProps(dialogProps)
+            setShowDialog(true)
+        }
+    }
+
+    const getBorderColor = () => {
+        if (data.selected) return theme.palette.primary.main
+        else if (theme?.customization?.isDarkMode) return theme.palette.grey[900] + 25
+        else return theme.palette.grey[900] + 50
+    }
+
+    return (
+        <>
+            <NodeCardWrapper
+                content={false}
+                sx={{
+                    padding: 0,
+                    borderColor: getBorderColor()
+                }}
+                border={false}
+            >
+                <Box>
+                    <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}>
+                        <Box style={{ width: 50, marginRight: 10, padding: 10 }}>
+                            <div
+                                style={{
+                                    ...theme.typography.commonAvatar,
+                                    ...theme.typography.largeAvatar,
+                                    borderRadius: '50%',
+                                    backgroundColor: 'white',
+                                    cursor: readOnly ? 'default' : 'grab',
+                                    width: '40px',
+                                    height: '40px'
+                                }}
+                            >
+                                <img
+                                    style={{ width: '100%', height: '100%', padding: 5, objectFit: 'contain' }}
+                                    src={`${baseURL}/api/v1/node-icon/${data.name}`}
+                                    alt='Node Icon'
+                                />
+                            </div>
+                        </Box>
+                        <Box>
+                            <Typography
+                                sx={{
+                                    fontSize: '1rem',
+                                    fontWeight: 500,
+                                    mr: 2
+                                }}
+                            >
+                                {data.label}
+                            </Typography>
+                        </Box>
+                        <div style={{ flexGrow: 1 }}></div>
+                        {data.tags && data.tags.includes('LlamaIndex') && (
+                            <>
+                                <div
+                                    style={{
+                                        borderRadius: '50%',
+                                        padding: 15
+                                    }}
+                                >
+                                    <img
+                                        style={{ width: '25px', height: '25px', borderRadius: '50%', objectFit: 'contain' }}
+                                        src={LlamaindexPNG}
+                                        alt='LlamaIndex'
+                                    />
+                                </div>
+                            </>
+                        )}
+                    </div>
+                    {(data.inputAnchors.length > 0 || data.inputParams.length > 0) && (
+                        <>
+                            <Divider />
+                            <Box sx={{ background: theme.palette.asyncSelect.main, p: 1 }}>
+                                <Typography
+                                    sx={{
+                                        fontWeight: 500,
+                                        textAlign: 'center'
+                                    }}
+                                >
+                                    Inputs
+                                </Typography>
+                            </Box>
+                            <Divider />
+                        </>
+                    )}
+                    {data.inputAnchors.map((inputAnchor, index) => (
+                        <NodeInputHandler disabled={readOnly} key={index} inputAnchor={inputAnchor} data={data} />
+                    ))}
+                    {data.inputParams
+                        .filter((inputParam) => !inputParam.hidden)
+                        .filter((inputParam) => inputParam.display !== false)
+                        .map((inputParam, index) => (
+                            <NodeInputHandler disabled={readOnly} key={index} inputParam={inputParam} data={data} />
+                        ))}
+                    {!readOnly && showAdditionalParams && data.inputParams.find((param) => param.additionalParams) && (
+                        <div
+                            style={{
+                                textAlign: 'center',
+                                marginTop:
+                                    data.inputParams.filter((param) => param.additionalParams).length ===
+                                    data.inputParams.length + data.inputAnchors.length
+                                        ? 20
+                                        : 0
+                            }}
+                        >
+                            <Button sx={{ borderRadius: 25, width: '90%', mb: 2 }} variant='outlined' onClick={onDialogClicked}>
+                                Additional Parameters
+                            </Button>
+                        </div>
+                    )}
+                    {data.outputAnchors.length > 0 && <Divider />}
+                    {data.outputAnchors.length > 0 && (
+                        <Box sx={{ background: theme.palette.asyncSelect.main, p: 1 }}>
+                            <Typography
+                                sx={{
+                                    fontWeight: 500,
+                                    textAlign: 'center'
+                                }}
+                            >
+                                Output
+                            </Typography>
+                        </Box>
+                    )}
+                    {data.outputAnchors.length > 0 && <Divider />}
+                    {data.outputAnchors.length > 0 &&
+                        data.outputAnchors.map((outputAnchor) => (
+                            <NodeOutputHandler disabled={readOnly} key={JSON.stringify(data)} outputAnchor={outputAnchor} data={data} />
+                        ))}
+                </Box>
+            </NodeCardWrapper>
+            {!readOnly && (
+                <AdditionalParamsDialog
+                    show={showDialog}
+                    dialogProps={dialogProps}
+                    onCancel={() => setShowDialog(false)}
+                />
+            )}
+        </>
+    )
+}
+
+FlowRendererNode.propTypes = {
+    data: PropTypes.object.isRequired,
+    readOnly: PropTypes.bool,
+    showAdditionalParams: PropTypes.bool
+}
+
+export default memo(FlowRendererNode)

--- a/packages/ui/src/components/FlowRenderer/FlowRendererStickyNote.jsx
+++ b/packages/ui/src/components/FlowRenderer/FlowRendererStickyNote.jsx
@@ -1,0 +1,82 @@
+import PropTypes from 'prop-types'
+import { memo } from 'react'
+
+// material-ui
+import { styled, useTheme } from '@mui/material/styles'
+import { Box, Typography } from '@mui/material'
+
+// project imports
+import MainCard from '@/ui-component/cards/MainCard'
+
+// icons
+import { IconNote } from '@tabler/icons-react'
+
+const CardWrapper = styled(MainCard)(({ theme }) => ({
+    background: '#FFF04B',
+    color: theme.darkTextPrimary,
+    border: 'solid 1px',
+    borderColor: '#FFF04B',
+    width: '300px',
+    height: 'auto',
+    padding: '10px',
+    boxShadow: '0 2px 14px 0 rgb(32 40 45 / 8%)'
+}))
+
+// ===========================|| FLOW RENDERER STICKY NOTE ||=========================== //
+
+/**
+ * FlowRendererStickyNote - Read-only version of StickyNote for FlowRenderer
+ */
+const FlowRendererStickyNote = ({ data, readOnly = true }) => {
+    const theme = useTheme()
+
+    const getBorderColor = () => {
+        if (data.selected) return theme.palette.primary.main
+        return '#FFF04B'
+    }
+
+    return (
+        <CardWrapper
+            content={false}
+            sx={{
+                padding: 0,
+                borderColor: getBorderColor(),
+                cursor: readOnly ? 'default' : 'grab'
+            }}
+            border={false}
+        >
+            <Box sx={{ p: 2 }}>
+                <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginBottom: 10 }}>
+                    <IconNote size={20} />
+                    <Typography
+                        sx={{
+                            fontSize: '1rem',
+                            fontWeight: 500,
+                            ml: 1
+                        }}
+                    >
+                        {data.label || 'Sticky Note'}
+                    </Typography>
+                </div>
+                {data.inputs?.note && (
+                    <Typography
+                        sx={{
+                            fontSize: '0.9rem',
+                            whiteSpace: 'pre-wrap',
+                            wordBreak: 'break-word'
+                        }}
+                    >
+                        {data.inputs.note}
+                    </Typography>
+                )}
+            </Box>
+        </CardWrapper>
+    )
+}
+
+FlowRendererStickyNote.propTypes = {
+    data: PropTypes.object.isRequired,
+    readOnly: PropTypes.bool
+}
+
+export default memo(FlowRendererStickyNote)

--- a/packages/ui/src/components/FlowRenderer/FlowRendererToggle.jsx
+++ b/packages/ui/src/components/FlowRenderer/FlowRendererToggle.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+
+// material-ui
+import { useTheme } from '@mui/material/styles'
+import { Avatar, ButtonBase, ToggleButton, ToggleButtonGroup } from '@mui/material'
+
+// icons
+import { IconEdit, IconEye } from '@tabler/icons-react'
+
+/**
+ * FlowRendererToggle - Toggle button to switch between Editor and Renderer modes
+ */
+const FlowRendererToggle = ({ mode, onModeChange, disabled = false }) => {
+    const theme = useTheme()
+
+    const handleChange = (event, newMode) => {
+        if (newMode !== null && !disabled) {
+            onModeChange(newMode)
+        }
+    }
+
+    return (
+        <ToggleButtonGroup
+            value={mode}
+            exclusive
+            onChange={handleChange}
+            aria-label="view mode"
+            size="small"
+            sx={{
+                mr: 2,
+                '& .MuiToggleButton-root': {
+                    border: 'none',
+                    borderRadius: '50%',
+                    width: 40,
+                    height: 40,
+                    transition: 'all .2s ease-in-out',
+                    '&.Mui-selected': {
+                        backgroundColor: theme.palette.primary.main,
+                        color: theme.palette.primary.contrastText,
+                        '&:hover': {
+                            backgroundColor: theme.palette.primary.dark
+                        }
+                    },
+                    '&:not(.Mui-selected)': {
+                        backgroundColor: theme.palette.secondary.light,
+                        color: theme.palette.secondary.dark,
+                        '&:hover': {
+                            backgroundColor: theme.palette.secondary.dark,
+                            color: theme.palette.secondary.light
+                        }
+                    }
+                }
+            }}
+        >
+            <ToggleButton value="editor" aria-label="editor mode" title="Editor Mode" disabled={disabled}>
+                <IconEdit size={20} />
+            </ToggleButton>
+            <ToggleButton value="renderer" aria-label="renderer mode" title="Renderer Mode" disabled={disabled}>
+                <IconEye size={20} />
+            </ToggleButton>
+        </ToggleButtonGroup>
+    )
+}
+
+FlowRendererToggle.propTypes = {
+    mode: PropTypes.oneOf(['editor', 'renderer']).isRequired,
+    onModeChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool
+}
+
+export default FlowRendererToggle

--- a/packages/ui/src/components/FlowRenderer/README.md
+++ b/packages/ui/src/components/FlowRenderer/README.md
@@ -1,0 +1,246 @@
+# FlowRenderer
+
+A read-only React component for rendering Flowise flows (node graphs) similar to n8n-demo. This component provides a stable public API for embedding Flowise flows in other applications or documentation.
+
+## Features
+
+- ✅ Read-only flow visualization
+- ✅ Support for both Chatflows and Agent Flows
+- ✅ Customizable node component mapping
+- ✅ MiniMap, Controls, and Background options
+- ✅ Click event handlers
+- ✅ Responsive design
+- ✅ Theme support (light/dark mode)
+- ✅ Editor ↔ Renderer toggle integration
+
+## Installation
+
+The FlowRenderer is part of the Flowise UI package. Import it directly:
+
+```javascript
+import FlowRenderer from '@/components/FlowRenderer'
+// or
+import { FlowRenderer } from '@/components/FlowRenderer'
+```
+
+## Basic Usage
+
+```jsx
+import React from 'react'
+import FlowRenderer from '@/components/FlowRenderer'
+
+const MyComponent = () => {
+  const flowData = {
+    nodes: [
+      {
+        id: 'node1',
+        type: 'customNode',
+        position: { x: 100, y: 100 },
+        data: {
+          label: 'Start Node',
+          // ... other node data
+        }
+      }
+    ],
+    edges: [
+      {
+        id: 'edge1',
+        source: 'node1',
+        target: 'node2',
+        type: 'buttonedge'
+      }
+    ]
+  }
+
+  return (
+    <div style={{ height: '600px' }}>
+      <FlowRenderer
+        flowData={flowData}
+        readOnly={true}
+        showControls={true}
+        showMiniMap={false}
+      />
+    </div>
+  )
+}
+```
+
+## API Reference
+
+### FlowRenderer Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `flowData` | `Object` | **Required** | Flowise flow JSON with `nodes` and `edges` arrays |
+| `readOnly` | `boolean` | `true` | Whether the flow is read-only (non-interactive) |
+| `showMiniMap` | `boolean` | `false` | Show the minimap navigation |
+| `showControls` | `boolean` | `true` | Show zoom and fit view controls |
+| `showBackground` | `boolean` | `true` | Show the background grid |
+| `nodeComponentMap` | `Object` | `{}` | Custom node component mappings |
+| `onNodeClick` | `Function` | `undefined` | Callback for node click events |
+| `onNodeDoubleClick` | `Function` | `undefined` | Callback for node double click events |
+| `style` | `Object` | `{}` | Custom styles for the container |
+| `className` | `string` | `''` | Custom CSS class |
+| `minZoom` | `number` | `0.1` | Minimum zoom level |
+| `maxZoom` | `number` | `2` | Maximum zoom level |
+| `fitView` | `boolean` | `true` | Fit view on initial render |
+
+### Flow Data Structure
+
+The `flowData` prop expects a Flowise flow JSON object with this structure:
+
+```javascript
+{
+  nodes: [
+    {
+      id: string,           // Unique node ID
+      type: string,         // Node type: 'customNode', 'agentFlow', 'stickyNote', etc.
+      position: { x, y },   // Node position
+      data: {               // Node data
+        label: string,      // Display label
+        name: string,       // Node name/type
+        inputs: Object,     // Input values
+        inputAnchors: [],   // Input connection points
+        outputAnchors: [],  // Output connection points
+        // ... other node properties
+      }
+    }
+  ],
+  edges: [
+    {
+      id: string,           // Unique edge ID
+      source: string,       // Source node ID
+      target: string,       // Target node ID
+      sourceHandle: string, // Source connection point
+      targetHandle: string, // Target connection point
+      type: string,         // Edge type: 'buttonedge', 'agentFlow', etc.
+    }
+  ]
+}
+```
+
+### Custom Node Components
+
+You can provide custom node components via the `nodeComponentMap` prop:
+
+```jsx
+import CustomNodeComponent from './CustomNodeComponent'
+
+<FlowRenderer
+  flowData={flowData}
+  nodeComponentMap={{
+    customNode: CustomNodeComponent,
+    myCustomType: MyCustomNodeComponent
+  }}
+/>
+```
+
+### Event Handlers
+
+```jsx
+const handleNodeClick = (event, node) => {
+  console.log('Node clicked:', node)
+}
+
+const handleNodeDoubleClick = (event, node) => {
+  console.log('Node double-clicked:', node)
+}
+
+<FlowRenderer
+  flowData={flowData}
+  onNodeClick={handleNodeClick}
+  onNodeDoubleClick={handleNodeDoubleClick}
+/>
+```
+
+## Built-in Node Types
+
+FlowRenderer supports these node types out of the box:
+
+- **customNode**: Standard Flowise chatflow nodes
+- **agentFlow**: Agent flow nodes with enhanced styling
+- **iteration**: Iteration nodes for agent flows
+- **stickyNote**: Sticky note nodes
+
+## Integration with Canvas
+
+FlowRenderer integrates seamlessly with the existing Canvas editor. When viewing a flow in the Canvas, you can toggle between Editor and Renderer modes using the toggle buttons in the header.
+
+## Demo
+
+Visit `/flowrenderer-demo` in the Flowise UI to see FlowRenderer in action with sample flows.
+
+## Styling
+
+FlowRenderer respects the current theme (light/dark mode) and uses Material-UI components for consistency with the rest of the Flowise UI.
+
+You can customize the appearance using:
+
+- `style` prop for container styles
+- `className` prop for custom CSS classes
+- Custom node components via `nodeComponentMap`
+
+## Examples
+
+### Chatflow Example
+
+```jsx
+<FlowRenderer
+  flowData={chatflowData}
+  readOnly={true}
+  showControls={true}
+  showBackground={true}
+  style={{ border: '1px solid #ccc', borderRadius: '8px' }}
+/>
+```
+
+### Agent Flow Example
+
+```jsx
+<FlowRenderer
+  flowData={agentflowData}
+  readOnly={true}
+  showMiniMap={true}
+  showControls={true}
+  onNodeClick={(event, node) => {
+    console.log('Agent node clicked:', node.data.label)
+  }}
+/>
+```
+
+### Embedded in Documentation
+
+```jsx
+// Perfect for embedding in docs or demos
+<div style={{ height: '400px', width: '100%' }}>
+  <FlowRenderer
+    flowData={exampleFlow}
+    readOnly={true}
+    showControls={false}
+    showBackground={false}
+    fitView={true}
+  />
+</div>
+```
+
+## Browser Support
+
+FlowRenderer works in all modern browsers that support React and ReactFlow:
+
+- Chrome 60+
+- Firefox 60+
+- Safari 12+
+- Edge 79+
+
+## Contributing
+
+FlowRenderer is part of the Flowise project. To contribute:
+
+1. Make changes in `packages/ui/src/components/FlowRenderer/`
+2. Test with the demo page at `/flowrenderer-demo`
+3. Update this documentation if needed
+4. Submit a pull request
+
+## License
+
+Same as Flowise project license.

--- a/packages/ui/src/components/FlowRenderer/index.js
+++ b/packages/ui/src/components/FlowRenderer/index.js
@@ -1,0 +1,8 @@
+export { default } from './FlowRenderer'
+export { default as FlowRenderer } from './FlowRenderer'
+export { default as FlowRendererNode } from './FlowRendererNode'
+export { default as FlowRendererAgentNode } from './FlowRendererAgentNode'
+export { default as FlowRendererStickyNote } from './FlowRendererStickyNote'
+export { default as FlowRendererToggle } from './FlowRendererToggle'
+export { default as CanvasHeaderWithToggle } from './CanvasHeaderWithToggle'
+export { default as EnhancedCanvas } from './EnhancedCanvas'

--- a/packages/ui/src/components/index.js
+++ b/packages/ui/src/components/index.js
@@ -1,0 +1,11 @@
+// FlowRenderer Components
+export { default as FlowRenderer } from './FlowRenderer/FlowRenderer'
+export { default as FlowRendererNode } from './FlowRenderer/FlowRendererNode'
+export { default as FlowRendererAgentNode } from './FlowRenderer/FlowRendererAgentNode'
+export { default as FlowRendererStickyNote } from './FlowRenderer/FlowRendererStickyNote'
+export { default as FlowRendererToggle } from './FlowRenderer/FlowRendererToggle'
+export { default as CanvasHeaderWithToggle } from './FlowRenderer/CanvasHeaderWithToggle'
+export { default as EnhancedCanvas } from './FlowRenderer/EnhancedCanvas'
+
+// Re-export the main FlowRenderer as default
+export { default } from './FlowRenderer/FlowRenderer'

--- a/packages/ui/src/menu-items/dashboard.js
+++ b/packages/ui/src/menu-items/dashboard.js
@@ -23,7 +23,8 @@ import {
     IconLockCheck,
     IconFileDatabase,
     IconShieldLock,
-    IconListCheck
+    IconListCheck,
+    IconEye
 } from '@tabler/icons-react'
 
 // constant
@@ -51,7 +52,8 @@ const icons = {
     IconLockCheck,
     IconFileDatabase,
     IconShieldLock,
-    IconListCheck
+    IconListCheck,
+    IconEye
 }
 
 // ==============================|| DASHBOARD MENU ITEMS ||============================== //
@@ -276,6 +278,15 @@ const dashboard = {
                 //     breadcrumbs: true,
                 //     display: 'feat:files',
                 // },
+                {
+                    id: 'flowrenderer-demo',
+                    title: 'FlowRenderer Demo',
+                    type: 'item',
+                    url: '/flowrenderer-demo',
+                    icon: icons.IconEye,
+                    breadcrumbs: true,
+                    permission: 'chatflows:view'
+                },
                 {
                     id: 'account',
                     title: 'Account Settings',

--- a/packages/ui/src/routes/MainRoutes.jsx
+++ b/packages/ui/src/routes/MainRoutes.jsx
@@ -61,6 +61,9 @@ const Logs = Loadable(lazy(() => import('@/views/serverlogs')))
 // executions routing
 const Executions = Loadable(lazy(() => import('@/views/agentexecutions')))
 
+// flowrenderer demo routing
+const FlowRendererDemo = Loadable(lazy(() => import('@/views/flowrenderer')))
+
 // enterprise features
 const UsersPage = Loadable(lazy(() => import('@/views/users')))
 const RolesPage = Loadable(lazy(() => import('@/views/roles')))
@@ -355,6 +358,14 @@ const MainRoutes = {
         {
             path: '/sso-success',
             element: <SSOSuccess />
+        },
+        {
+            path: '/flowrenderer-demo',
+            element: (
+                <RequireAuth permission={'chatflows:view'}>
+                    <FlowRendererDemo />
+                </RequireAuth>
+            )
         }
     ]
 }

--- a/packages/ui/src/views/canvas/CanvasHeader.jsx
+++ b/packages/ui/src/views/canvas/CanvasHeader.jsx
@@ -5,10 +5,10 @@ import { useEffect, useRef, useState } from 'react'
 
 // material-ui
 import { useTheme } from '@mui/material/styles'
-import { Avatar, Box, ButtonBase, Typography, Stack, TextField, Button } from '@mui/material'
+import { Avatar, Box, ButtonBase, Typography, Stack, TextField, Button, ToggleButton, ToggleButtonGroup } from '@mui/material'
 
 // icons
-import { IconSettings, IconChevronLeft, IconDeviceFloppy, IconPencil, IconCheck, IconX, IconCode } from '@tabler/icons-react'
+import { IconSettings, IconChevronLeft, IconDeviceFloppy, IconPencil, IconCheck, IconX, IconCode, IconEdit, IconEye } from '@tabler/icons-react'
 
 // project imports
 import Settings from '@/views/settings'
@@ -34,7 +34,7 @@ import { closeSnackbar as closeSnackbarAction, enqueueSnackbar as enqueueSnackba
 
 // ==============================|| CANVAS HEADER ||============================== //
 
-const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, handleDeleteFlow, handleLoadFlow }) => {
+const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, handleDeleteFlow, handleLoadFlow, viewMode, onViewModeChange }) => {
     const theme = useTheme()
     const dispatch = useDispatch()
     const navigate = useNavigate()
@@ -64,6 +64,12 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
     const [savePermission, setSavePermission] = useState(isAgentCanvas ? 'agentflows:create' : 'chatflows:create')
 
     const title = isAgentCanvas ? 'Agents' : 'Chatflow'
+
+    const handleViewModeChange = (event, newMode) => {
+        if (newMode !== null && onViewModeChange) {
+            onViewModeChange(newMode)
+        }
+    }
 
     const updateChatflowApi = useApi(chatflowsApi.updateChatflow)
     const canvas = useSelector((state) => state.canvas)
@@ -387,7 +393,50 @@ const CanvasHeader = ({ chatflow, isAgentCanvas, isAgentflowV2, handleSaveFlow, 
                         )}
                     </Box>
                 </Stack>
-                <Box>
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    {/* View Mode Toggle */}
+                    {chatflow?.flowData && viewMode && onViewModeChange && (
+                        <ToggleButtonGroup
+                            value={viewMode}
+                            exclusive
+                            onChange={handleViewModeChange}
+                            aria-label="view mode"
+                            size="small"
+                            sx={{
+                                mr: 2,
+                                '& .MuiToggleButton-root': {
+                                    border: 'none',
+                                    borderRadius: '50%',
+                                    width: 40,
+                                    height: 40,
+                                    transition: 'all .2s ease-in-out',
+                                    '&.Mui-selected': {
+                                        backgroundColor: theme.palette.primary.main,
+                                        color: theme.palette.primary.contrastText,
+                                        '&:hover': {
+                                            backgroundColor: theme.palette.primary.dark
+                                        }
+                                    },
+                                    '&:not(.Mui-selected)': {
+                                        backgroundColor: theme.palette.secondary.light,
+                                        color: theme.palette.secondary.dark,
+                                        '&:hover': {
+                                            backgroundColor: theme.palette.secondary.dark,
+                                            color: theme.palette.secondary.light
+                                        }
+                                    }
+                                }
+                            }}
+                        >
+                            <ToggleButton value="editor" aria-label="editor mode" title="Editor Mode">
+                                <IconEdit size={20} />
+                            </ToggleButton>
+                            <ToggleButton value="renderer" aria-label="renderer mode" title="Renderer Mode">
+                                <IconEye size={20} />
+                            </ToggleButton>
+                        </ToggleButtonGroup>
+                    )}
+                    
                     {chatflow?.id && (
                         <ButtonBase title='API Endpoint' sx={{ borderRadius: '50%', mr: 2 }}>
                             <Avatar
@@ -508,7 +557,9 @@ CanvasHeader.propTypes = {
     handleDeleteFlow: PropTypes.func,
     handleLoadFlow: PropTypes.func,
     isAgentCanvas: PropTypes.bool,
-    isAgentflowV2: PropTypes.bool
+    isAgentflowV2: PropTypes.bool,
+    viewMode: PropTypes.oneOf(['editor', 'renderer']),
+    onViewModeChange: PropTypes.func
 }
 
 export default CanvasHeader

--- a/packages/ui/src/views/canvas/index.jsx
+++ b/packages/ui/src/views/canvas/index.jsx
@@ -27,6 +27,7 @@ import ConfirmDialog from '@/ui-component/dialog/ConfirmDialog'
 import ChatPopUp from '@/views/chatmessage/ChatPopUp'
 import VectorStorePopUp from '@/views/vectorstore/VectorStorePopUp'
 import { flowContext } from '@/store/context/ReactFlowContext'
+import FlowRenderer from '@/components/FlowRenderer'
 
 // API
 import nodesApi from '@/api/nodes'
@@ -98,6 +99,7 @@ const Canvas = () => {
     const [isUpsertButtonEnabled, setIsUpsertButtonEnabled] = useState(false)
     const [isSyncNodesButtonEnabled, setIsSyncNodesButtonEnabled] = useState(false)
     const [isSnappingEnabled, setIsSnappingEnabled] = useState(false)
+    const [viewMode, setViewMode] = useState('editor')
 
     const reactFlowWrapper = useRef(null)
 
@@ -576,13 +578,26 @@ const Canvas = () => {
                             handleDeleteFlow={handleDeleteFlow}
                             handleLoadFlow={handleLoadFlow}
                             isAgentCanvas={isAgentCanvas}
+                            viewMode={viewMode}
+                            onViewModeChange={setViewMode}
                         />
                     </Toolbar>
                 </AppBar>
                 <Box sx={{ pt: '70px', height: '100vh', width: '100%' }}>
-                    <div className='reactflow-parent-wrapper'>
-                        <div className='reactflow-wrapper' ref={reactFlowWrapper}>
-                            <ReactFlow
+                    {viewMode === 'renderer' && chatflow?.flowData ? (
+                        <FlowRenderer
+                            flowData={JSON.parse(chatflow.flowData)}
+                            readOnly={true}
+                            showMiniMap={true}
+                            showControls={true}
+                            showBackground={true}
+                            style={{ height: '100%' }}
+                            onNodeClick={(event, node) => console.log('Node clicked in renderer:', node)}
+                        />
+                    ) : (
+                        <div className='reactflow-parent-wrapper'>
+                            <div className='reactflow-wrapper' ref={reactFlowWrapper}>
+                                <ReactFlow
                                 nodes={nodes}
                                 edges={edges}
                                 onNodesChange={onNodesChange}
@@ -649,6 +664,7 @@ const Canvas = () => {
                             </ReactFlow>
                         </div>
                     </div>
+                    )}
                 </Box>
                 <ConfirmDialog />
             </Box>

--- a/packages/ui/src/views/flowrenderer/index.jsx
+++ b/packages/ui/src/views/flowrenderer/index.jsx
@@ -1,0 +1,360 @@
+import React, { useState, useEffect } from 'react'
+import { useSelector } from 'react-redux'
+
+// material-ui
+import { 
+    Box, 
+    Typography, 
+    Button, 
+    Card, 
+    CardContent, 
+    Grid, 
+    ToggleButton, 
+    ToggleButtonGroup,
+    FormControlLabel,
+    Switch,
+    Divider
+} from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+
+// project imports
+import MainCard from '@/ui-component/cards/MainCard'
+import ViewHeader from '@/layout/MainLayout/ViewHeader'
+import FlowRenderer from '@/components/FlowRenderer'
+
+// icons
+import { IconEye, IconCode, IconDownload } from '@tabler/icons-react'
+
+// Sample flow data for demo
+const SAMPLE_CHATFLOW = {
+    "nodes": [
+        {
+            "width": 300,
+            "height": 513,
+            "id": "promptTemplate_0",
+            "position": { "x": 100, "y": 100 },
+            "type": "customNode",
+            "data": {
+                "id": "promptTemplate_0",
+                "label": "Prompt Template",
+                "version": 1,
+                "name": "promptTemplate",
+                "type": "PromptTemplate",
+                "baseClasses": ["PromptTemplate", "BaseStringPromptTemplate", "BasePromptTemplate"],
+                "category": "Prompts",
+                "description": "Schema to represent a basic prompt for an LLM",
+                "inputParams": [
+                    {
+                        "label": "Template",
+                        "name": "template",
+                        "type": "string",
+                        "rows": 4,
+                        "placeholder": "What is a good name for a company that makes {product}?",
+                        "id": "promptTemplate_0-input-template-string"
+                    }
+                ],
+                "inputAnchors": [],
+                "inputs": {
+                    "template": "What is a good name for a company that makes {product}?"
+                },
+                "outputAnchors": [
+                    {
+                        "id": "promptTemplate_0-output-promptTemplate-PromptTemplate",
+                        "name": "promptTemplate",
+                        "label": "PromptTemplate",
+                        "type": "PromptTemplate | BaseStringPromptTemplate | BasePromptTemplate"
+                    }
+                ],
+                "outputs": {},
+                "selected": false
+            }
+        },
+        {
+            "width": 300,
+            "height": 400,
+            "id": "llmChain_0",
+            "position": { "x": 500, "y": 100 },
+            "type": "customNode",
+            "data": {
+                "id": "llmChain_0",
+                "label": "LLM Chain",
+                "version": 3,
+                "name": "llmChain",
+                "type": "LLMChain",
+                "baseClasses": ["LLMChain", "BaseChain", "Runnable"],
+                "category": "Chains",
+                "description": "Chain to run queries against LLMs",
+                "inputParams": [],
+                "inputAnchors": [
+                    {
+                        "label": "Language Model",
+                        "name": "model",
+                        "type": "BaseLanguageModel",
+                        "id": "llmChain_0-input-model-BaseLanguageModel"
+                    },
+                    {
+                        "label": "Prompt",
+                        "name": "prompt",
+                        "type": "BasePromptTemplate",
+                        "id": "llmChain_0-input-prompt-BasePromptTemplate"
+                    }
+                ],
+                "inputs": {
+                    "model": "{{chatOpenAI_0.data.instance}}",
+                    "prompt": "{{promptTemplate_0.data.instance}}"
+                },
+                "outputAnchors": [
+                    {
+                        "id": "llmChain_0-output-llmChain-LLMChain",
+                        "name": "output",
+                        "label": "Output",
+                        "type": "LLMChain | BaseChain | Runnable"
+                    }
+                ],
+                "outputs": {},
+                "selected": false
+            }
+        }
+    ],
+    "edges": [
+        {
+            "source": "promptTemplate_0",
+            "sourceHandle": "promptTemplate_0-output-promptTemplate-PromptTemplate",
+            "target": "llmChain_0",
+            "targetHandle": "llmChain_0-input-prompt-BasePromptTemplate",
+            "type": "buttonedge",
+            "id": "edge-1",
+            "data": { "label": "" }
+        }
+    ]
+}
+
+const SAMPLE_AGENTFLOW = {
+    "nodes": [
+        {
+            "id": "startAgentflow_0",
+            "position": { "x": 100, "y": 200 },
+            "type": "agentFlow",
+            "data": {
+                "id": "startAgentflow_0",
+                "label": "Start",
+                "name": "startAgentflow",
+                "type": "Start",
+                "color": "#3b82f6",
+                "hideInput": true,
+                "outputAnchors": [
+                    {
+                        "id": "startAgentflow_0-output-start",
+                        "name": "start",
+                        "label": "Start"
+                    }
+                ]
+            },
+            "width": 200,
+            "height": 60
+        },
+        {
+            "id": "agent_0", 
+            "position": { "x": 400, "y": 200 },
+            "type": "agentFlow",
+            "data": {
+                "id": "agent_0",
+                "label": "Research Agent",
+                "name": "agent",
+                "type": "Agent",
+                "color": "#10b981",
+                "inputs": {
+                    "agentModel": "chatOpenAI",
+                    "agentModelConfig": { "modelName": "gpt-4" }
+                },
+                "outputAnchors": [
+                    {
+                        "id": "agent_0-output-agent",
+                        "name": "agent", 
+                        "label": "Agent"
+                    }
+                ]
+            },
+            "width": 200,
+            "height": 80
+        }
+    ],
+    "edges": [
+        {
+            "source": "startAgentflow_0",
+            "sourceHandle": "startAgentflow_0-output-start",
+            "target": "agent_0", 
+            "targetHandle": "agent_0",
+            "type": "agentFlow",
+            "id": "edge-agentflow-1"
+        }
+    ]
+}
+
+// ==============================|| FLOW RENDERER DEMO ||============================== //
+
+const FlowRendererDemo = () => {
+    const theme = useTheme()
+    const customization = useSelector((state) => state.customization)
+    
+    const [selectedFlow, setSelectedFlow] = useState('chatflow')
+    const [currentFlowData, setCurrentFlowData] = useState(SAMPLE_CHATFLOW)
+    const [showMiniMap, setShowMiniMap] = useState(false)
+    const [showControls, setShowControls] = useState(true)
+    const [showBackground, setShowBackground] = useState(true)
+
+    // Switch between different flow types
+    useEffect(() => {
+        setCurrentFlowData(selectedFlow === 'chatflow' ? SAMPLE_CHATFLOW : SAMPLE_AGENTFLOW)
+    }, [selectedFlow])
+
+    const handleFlowTypeChange = (event, newType) => {
+        if (newType !== null) {
+            setSelectedFlow(newType)
+        }
+    }
+
+    const handleNodeClick = (event, node) => {
+        console.log('Node clicked:', node)
+    }
+
+    const downloadFlowData = () => {
+        const dataStr = JSON.stringify(currentFlowData, null, 2)
+        const dataUri = 'data:application/json;charset=utf-8,'+ encodeURIComponent(dataStr)
+        
+        const exportFileDefaultName = `${selectedFlow}-sample.json`
+        
+        const linkElement = document.createElement('a')
+        linkElement.setAttribute('href', dataUri)
+        linkElement.setAttribute('download', exportFileDefaultName)
+        linkElement.click()
+    }
+
+    return (
+        <MainCard>
+            <ViewHeader title="FlowRenderer Demo" />
+            
+            <Grid container spacing={2}>
+                {/* Controls Panel */}
+                <Grid item xs={12}>
+                    <Card>
+                        <CardContent>
+                            <Typography variant="h6" gutterBottom>
+                                Demo Controls
+                            </Typography>
+                            
+                            <Box sx={{ mb: 2 }}>
+                                <Typography variant="body2" sx={{ mb: 1 }}>
+                                    Flow Type:
+                                </Typography>
+                                <ToggleButtonGroup
+                                    value={selectedFlow}
+                                    exclusive
+                                    onChange={handleFlowTypeChange}
+                                    aria-label="flow type"
+                                    size="small"
+                                >
+                                    <ToggleButton value="chatflow" aria-label="chatflow">
+                                        Chatflow
+                                    </ToggleButton>
+                                    <ToggleButton value="agentflow" aria-label="agentflow">
+                                        Agent Flow
+                                    </ToggleButton>
+                                </ToggleButtonGroup>
+                            </Box>
+
+                            <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', mb: 2 }}>
+                                <FormControlLabel
+                                    control={
+                                        <Switch
+                                            checked={showMiniMap}
+                                            onChange={(e) => setShowMiniMap(e.target.checked)}
+                                            size="small"
+                                        />
+                                    }
+                                    label="Show MiniMap"
+                                />
+                                <FormControlLabel
+                                    control={
+                                        <Switch
+                                            checked={showControls}
+                                            onChange={(e) => setShowControls(e.target.checked)}
+                                            size="small"
+                                        />
+                                    }
+                                    label="Show Controls"
+                                />
+                                <FormControlLabel
+                                    control={
+                                        <Switch
+                                            checked={showBackground}
+                                            onChange={(e) => setShowBackground(e.target.checked)}
+                                            size="small"
+                                        />
+                                    }
+                                    label="Show Background"
+                                />
+                            </Box>
+
+                            <Box sx={{ display: 'flex', gap: 1 }}>
+                                <Button
+                                    variant="outlined"
+                                    size="small"
+                                    startIcon={<IconDownload />}
+                                    onClick={downloadFlowData}
+                                >
+                                    Download Sample JSON
+                                </Button>
+                            </Box>
+                        </CardContent>
+                    </Card>
+                </Grid>
+
+                {/* Flow Renderer */}
+                <Grid item xs={12}>
+                    <Card>
+                        <CardContent sx={{ p: 0 }}>
+                            <Box sx={{ height: 600, width: '100%' }}>
+                                <FlowRenderer
+                                    flowData={currentFlowData}
+                                    readOnly={true}
+                                    showMiniMap={showMiniMap}
+                                    showControls={showControls}
+                                    showBackground={showBackground}
+                                    onNodeClick={handleNodeClick}
+                                    style={{ border: '1px solid #e0e0e0' }}
+                                />
+                            </Box>
+                        </CardContent>
+                    </Card>
+                </Grid>
+
+                {/* Flow Data Preview */}
+                <Grid item xs={12}>
+                    <Card>
+                        <CardContent>
+                            <Typography variant="h6" gutterBottom>
+                                Current Flow JSON
+                            </Typography>
+                            <Box
+                                sx={{
+                                    backgroundColor: theme.customization?.isDarkMode ? '#1e1e1e' : '#f5f5f5',
+                                    borderRadius: 1,
+                                    p: 2,
+                                    maxHeight: 400,
+                                    overflow: 'auto'
+                                }}
+                            >
+                                <pre style={{ margin: 0, fontSize: '0.8rem' }}>
+                                    {JSON.stringify(currentFlowData, null, 2)}
+                                </pre>
+                            </Box>
+                        </CardContent>
+                    </Card>
+                </Grid>
+            </Grid>
+        </MainCard>
+    )
+}
+
+export default FlowRendererDemo


### PR DESCRIPTION
Introduce a read-only FlowRenderer component and integrate a toggle into the Canvas view to allow embedding and previewing Flowise flows.

This component provides a stable public API for rendering Flowise flows (chatflows and agent flows) without the full editor UI, making it useful for documentation, demos, and external applications.

---
<a href="https://cursor.com/background-agent?bcId=bc-5edc653b-a83e-49e5-8d9f-47383c53dd41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5edc653b-a83e-49e5-8d9f-47383c53dd41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

